### PR TITLE
COMP: Fix packaging updating CMake project name to match catalog entry filename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.3...3.19.7 FATAL_ERROR)
 
-project(ANTsPy)
+project(SlicerANTsPy)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information


### PR DESCRIPTION
This fixes the following error:

```
[100%] Package and upload extension
CPack log: /.../SlicerANTsPy-build/./packageupload_cpack_output.txt
CMake Error at /D/P/S-0/Extensions/CMake/SlicerFunctionExtractExtensionDescription.cmake:135 (message):
  error: EXTENSION_FILE CMake variable points to a inexistent file or
  directory:
  /.../SlicerANTsPy-build/./ANTsPy.json
Call Stack (most recent call first):
  /D/P/S-0/Extensions/CMake/SlicerExtensionPackageAndUploadTarget.cmake:210 (slicerFunctionExtractExtensionDescriptionFromJson)
```