### PR TITLE
Add Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,37 @@
+name: Claude Code Review
+
+# Automatically review every pull request with Claude (Max-subscription OAuth token).
+# No github_token override -> posts as the Claude GitHub App ("Claude"), not github-actions[bot].
+# NOTE: in app mode the action only runs when this file matches the default branch, so it does
+# NOT review PRs that modify the workflow itself; it reviews normal PRs after this is merged.
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request for correctness bugs, security issues,
+            edge cases, and regressions. Prefer a few high-confidence findings
+            over many speculative ones. Follow the conventions in CLAUDE.md if present.
+            Use inline comments for specific lines and a top-level comment for a brief summary.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Adds the same `claude-code-review.yml` the other SlicerMorph extension repos use (copied from SlicerDenseCorrespondenceAnalysis). Every pull request gets reviewed by Claude, posting as the Claude GitHub App.

**Before it can run**, a `CLAUDE_CODE_OAUTH_TOKEN` repository secret is needed: Settings -> Secrets and variables -> Actions -> New repository secret. SlicerMorph and SlicerDenseCorrespondenceAnalysis already have one; secrets cannot be read back, so the value has to be re-entered here.

In app mode the action only runs when the workflow file matches the default branch, so it does not review this PR. It starts reviewing pull requests once this is merged - including #35, which can be re-triggered with an empty commit.